### PR TITLE
Use a fixed tag for the ActiveMQ image

### DIFF
--- a/charts/ark-activemq/values.yaml
+++ b/charts/ark-activemq/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 1
 image:
   repository: 345280441424.dkr.ecr.ap-south-1.amazonaws.com/ark_activemq
   pullPolicy: IfNotPresent
-  tag: latest
+  tag: 20210716-45b2fb2
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
After reflection, I think it is not correct to use a floating tag. A specific Helm chart is built for a specific version of the app it manages, so I think I should use a fixed tag to pull the Docker image rather than a floating tag.