### PR TITLE
Feature/aws rds

### DIFF
--- a/src/app/charts/rdbms/templates/secrets.yaml
+++ b/src/app/charts/rdbms/templates/secrets.yaml
@@ -1,3 +1,3 @@
-{{- if and (include "arkcase.subsystem.enabled" $) (not (include "arkcase.rdbms.external" $)) -}}
+{{- if or (and (include "arkcase.subsystem.enabled" $) (not (include "arkcase.rdbms.external" $))) (include "arkcase.rdbms.external" $) -}}
   {{- include "arkcase.initDatabase.secret" $ -}}
 {{- end }}

--- a/src/app/templates/rds-instance.yaml
+++ b/src/app/templates/rds-instance.yaml
@@ -1,0 +1,40 @@
+apiVersion: database.aws.crossplane.io/v1beta1
+kind: RDSInstance
+metadata:
+  name: fedramp-stage-client2
+  annotations:
+    "helm.sh/hook": pre-install
+spec:
+  forProvider:
+    dbSubnetGroupName: "fedramp-stage-rds-subnets" #assume from platform ${application}-${lifecyle}-rds-subnets
+    allocatedStorage: 20
+    applyModificationsImmediately: true
+    autoMinorVersionUpgrade: true
+    backupRetentionPeriod: 0
+    caCertificateIdentifier: rds-ca-2019
+    copyTagsToSnapshot: false
+    dbInstanceClass: db.t3.medium
+    deletionProtection: false
+    enableIAMDatabaseAuthentication: false
+    enablePerformanceInsights: false
+    engine: mariadb
+    engineVersion: "10.6"
+    skipFinalSnapshotBeforeDeletion: true
+    licenseModel: general-public-license
+    masterUsername: arkcase
+    # dbName: arkcase
+    # masterPasswordSecretRef:
+    #   key: arkcase
+    #   name: arkcase-rdbms-database-init
+    #   namespace: cust-dc-owc
+    multiAZ: false
+    port: 3306
+    publiclyAccessible: false
+    region: us-east-1
+    storageEncrypted: false
+    storageType: standard
+  providerConfigRef:
+    name: aws-crossplane-config # assume from platform, always this name
+  writeConnectionSecretToRef:
+    name: fedramp-stage-client2-dbinfo
+    namespace: cust-dc-owc

--- a/src/app/templates/rds-instance.yaml
+++ b/src/app/templates/rds-instance.yaml
@@ -22,11 +22,11 @@ spec:
     skipFinalSnapshotBeforeDeletion: true
     licenseModel: general-public-license
     masterUsername: arkcase
-    # dbName: arkcase
-    # masterPasswordSecretRef:
-    #   key: arkcase
-    #   name: arkcase-rdbms-database-init
-    #   namespace: cust-dc-owc
+    dbName: arkcase
+    masterPasswordSecretRef:
+      key: arkcase
+      name: arkcase-rdbms-database-init
+      namespace: cust-dc-owc
     multiAZ: false
     port: 3306
     publiclyAccessible: false
@@ -35,6 +35,7 @@ spec:
     storageType: standard
   providerConfigRef:
     name: aws-crossplane-config # assume from platform, always this name
-  writeConnectionSecretToRef:
-    name: fedramp-stage-client2-dbinfo
-    namespace: cust-dc-owc
+# New secret with endpoint, username, password
+  # writeConnectionSecretToRef:
+  #   name: fedramp-stage-client2-dbinfo
+  #   namespace: cust-dc-owc


### PR DESCRIPTION
*Note on all: we use helm install .... for deployments, so this approach currently is "not suited"??

global:
  conf:
    rdbms:
      dialect: mysql
      hostname: "aws.rds.endpoint"

Interesting bit, aws rds endpoint is always the same, no matter how much i delete/create the instance (that is why i hardcoded here b/c i know what that endpoint is).

This approach remove rdbms pod and service and other rdbms configs, but only creates the secret arkcase-rdbms-database-init where users and passwords are already set up for all necessary databases (pentaho, arkcase).