### PR TITLE
ADS-2639: properly configure portal authentication type

### DIFF
--- a/src/app/Chart.yaml
+++ b/src/app/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: app
-version: 0.8.0-37
+version: 0.8.0-38
 appVersion: "24.09.00"
 description: ArkCase Application Chart
 type: application

--- a/src/app/charts/core/Chart.yaml
+++ b/src/app/charts/core/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: core
-version: 0.8.0-23
+version: 0.8.0-24
 appVersion: "3.0.0"
 description: A Helm chart for core ArkCase and ConfigServer
 type: application

--- a/src/app/charts/core/files/config/tpl/arkcase-portal-server.yaml
+++ b/src/app/charts/core/files/config/tpl/arkcase-portal-server.yaml
@@ -18,7 +18,13 @@ portal:
   arkcaseUrl: "https://localhost:8443/arkcase"
   groupName: "ARKCASE_PORTAL_USER@${PORTAL_LDAP_DOMAIN_UPPER}"
   # authentication type, possible values (basic, external)
+  {{- $saml := (include "arkcase.core.sso.saml" $ | fromYaml) }}
+  {{- $oidc := (include "arkcase.core.sso.oidc" $ | fromYaml) -}}
+  {{- if or $saml $oidc }}
+  authenticationType: "external"
+  {{- else }}
   authenticationType: "basic"
+  {{- end }}
   userId: "${PORTAL_ADMIN_USERNAME}@${PORTAL_LDAP_DOMAIN}"
   password: "${PORTAL_ADMIN_PASSWORD}"
   # portal configuration type


### PR DESCRIPTION
When SAML or OIDC is used, the portal authentication type must be "external", otherwise it can be "basic".