### PR TITLE
Implement Portal SSO

### DIFF
--- a/src/app/Chart.yaml
+++ b/src/app/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: app
-version: 0.8.0-76
+version: 0.8.0-77
 appVersion: "24.09.02"
 description: ArkCase Application Chart
 type: application

--- a/src/app/charts/core/Chart.yaml
+++ b/src/app/charts/core/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: core
-version: 0.8.0-48
+version: 0.8.0-49
 appVersion: "3.0.0"
 description: A Helm chart for core ArkCase and ConfigServer
 type: application

--- a/src/app/charts/core/files/config/tpl/arkcase-portal-server.yaml
+++ b/src/app/charts/core/files/config/tpl/arkcase-portal-server.yaml
@@ -51,7 +51,7 @@ portal:
     header.parameter.name: foia-api-secret
     token:  {{ $portal.apiSecret | quote }}
 
-{{- if $portalSSO }}
+  {{- if $portalSSO }}
 oidc:
     {{- toYaml $portalSSO.conf.clients.portal | nindent 2 -}}
   {{- end }}

--- a/src/app/charts/core/files/config/tpl/arkcase-portal-server.yaml
+++ b/src/app/charts/core/files/config/tpl/arkcase-portal-server.yaml
@@ -51,8 +51,5 @@ portal:
     header.parameter.name: foia-api-secret
     token:  {{ $portal.apiSecret | quote }}
 
-  {{- if $portalSSO }}
-oidc:
-    {{- toYaml $portalSSO.conf.clients.portal | nindent 2 -}}
-  {{- end }}
+oidc: {{- if $portalSSO }} {{ toYaml $portalSSO.conf.clients.portal | nindent 2 }} {{- end }}
 {{- end -}}

--- a/src/app/charts/core/files/config/tpl/arkcase-portal-server.yaml
+++ b/src/app/charts/core/files/config/tpl/arkcase-portal-server.yaml
@@ -2,6 +2,8 @@
 {{- if $portal -}}
   {{- $baseUrl := (include "arkcase.tools.parseUrl" (include "arkcase.tools.conf" (dict "ctx" $ "value" "baseUrl")) | fromYaml) -}}
   {{- $uiApplicationHost := (printf "%s://%s" $baseUrl.scheme $baseUrl.host) -}}
+  {{- $portalSSO := (include "arkcase.core.portal.sso" $ | fromYaml) -}}
+
 logging:
   level:
     com.arkcase.portal: debug
@@ -25,6 +27,10 @@ portal:
   {{- else }}
   authenticationType: "basic"
   {{- end }}
+  {{- if $portalSSO }}
+  loginGov: true
+  oidc: true
+  {{- end }}
   userId: "${PORTAL_ADMIN_USERNAME}@${PORTAL_LDAP_DOMAIN}"
   password: "${PORTAL_ADMIN_PASSWORD}"
   homeDir: "${PORTAL_HOME_DIR}"
@@ -44,4 +50,9 @@ portal:
   security.authentication:
     header.parameter.name: foia-api-secret
     token:  {{ $portal.apiSecret | quote }}
+
+{{- if $portalSSO }}
+oidc:
+    {{- toYaml $portalSSO.conf.clients.portal | nindent 2 -}}
+  {{- end }}
 {{- end -}}

--- a/src/app/charts/core/files/config/tpl/bootstrap.yaml
+++ b/src/app/charts/core/files/config/tpl/bootstrap.yaml
@@ -23,8 +23,7 @@ spring:
         initial-interval: 10000
 
   profiles:
-    # TODO: Replace this with the template to selectively enable the OIDC template
-    active: ""
+    active: {{ include "arkcase.portal.springProfiles" $ | fromYamlArray | compact | join "," | quote }}
     include: {{ $profiles | compact | join "," | quote }}
 
   jms:

--- a/src/app/charts/core/templates/_helpers-sso.tpl
+++ b/src/app/charts/core/templates/_helpers-sso.tpl
@@ -141,9 +141,7 @@ idp.xml
       {{- $required := $requiredCommon -}}
 
       {{- if eq $id "portal" -}}
-        {{- $required = append $required "clientAuthentication" -}}
-        {{- $required = append $required "logOutRedirectUri" -}}
-        {{- $required = append $required "grantType" -}}
+        {{- $required = concat $required (list "clientAuthentication" "logOutRedirectUri" "grantType") -}}
 
         {{- /* Set the redirectUri to the specified value */ -}}
         {{- $portal := (include "arkcase.portal" $.ctx | fromYaml) -}}
@@ -152,8 +150,7 @@ idp.xml
 
         {{- if hasKey $client "clientAuthentication" -}}
           {{- if eq $client.clientAuthentication "private_key_jwt" -}}
-            {{- $required = append $required "privateKeyFilePath" -}}
-            {{- $required = append $required "clientAssertionType" -}}
+            {{- $required = concat $required (list "privateKeyFilePath" "clientAssertionType") -}}
           {{- else if eq $client.clientAuthentication "client_id_and_secret" -}}
             {{- $required = append $required "clientSecret" -}}
           {{- end -}}
@@ -161,10 +158,7 @@ idp.xml
           {{- fail (printf "OIDC Configuration for client '%s' is missing 'clientAuthentication'" $id) -}}
         {{- end -}}
       {{- else -}}
-        {{- $required = append $required "clientSecret" -}}
-        {{- $required = append $required "responseMode" -}}
-        {{- $required = append $required "usernameAttribute" -}}
-        {{- $required = append $required "registrationId" -}}
+        {{- $required = concat $required (list "clientSecret" "responseMode" "usernameAttribute" "registrationId") -}}
 
         {{- /* Set the redirectUri to the specified value */ -}}
         {{- $baseUrlArkcase := (printf "%s/login/oauth2/code" $.baseUrl.baseUrl) -}}

--- a/src/app/charts/core/templates/_helpers.tpl
+++ b/src/app/charts/core/templates/_helpers.tpl
@@ -620,6 +620,12 @@
     {{- end -}}
   {{- end -}}
 
+  {{- /* Add the portal OIDC profile */ -}}
+  {{- $portalSso := (include "arkcase.core.portal.sso" $ | fromYaml) -}}
+  {{- if $portalSso -}}
+    {{- $result = append $result "portalOidc" -}}
+  {{- end -}}
+
   {{- /* Add any profiles the integrations required */ -}}
   {{- range $key, $data := (include "arkcase.core.integrations" $ | fromYaml) -}}
     {{- $result = concat $result ($data.profiles | default list) -}}

--- a/src/app/charts/core/templates/_helpers.tpl
+++ b/src/app/charts/core/templates/_helpers.tpl
@@ -620,12 +620,6 @@
     {{- end -}}
   {{- end -}}
 
-  {{- /* Add the portal OIDC profile */ -}}
-  {{- $portalSso := (include "arkcase.core.portal.sso" $ | fromYaml) -}}
-  {{- if $portalSso -}}
-    {{- $result = append $result "portalOidc" -}}
-  {{- end -}}
-
   {{- /* Add any profiles the integrations required */ -}}
   {{- range $key, $data := (include "arkcase.core.integrations" $ | fromYaml) -}}
     {{- $result = concat $result ($data.profiles | default list) -}}

--- a/src/common/templates/_ark-portal.tpl
+++ b/src/common/templates/_ark-portal.tpl
@@ -124,3 +124,18 @@
   -}}
   {{- include "__arkcase.tools.getCachedValue" $args -}}
 {{- end -}}
+
+{{- define "arkcase.portal.springProfiles" -}}
+  {{- $ctx := $ -}}
+  {{- if not (include "arkcase.isRootContext" $ctx) -}}
+    {{- fail "Must send the root context as the only parameter" -}}
+  {{- end -}}
+
+  {{- $portalSSO := (include "arkcase.core.portal.sso" $ | fromYaml) -}}
+  {{- $result := list -}}
+  {{- if $portalSSO }}
+    {{- $result = append $result "oidc" -}}
+  {{- end }}
+
+  {{- $result | uniq | toYaml -}}
+{{- end -}}


### PR DESCRIPTION
- Add new profile portalOidc for portal spring profile
- Add list of common required fields for both ArkCase and portal, and append separate required fields for each of the configurations
- Write the portal configuration SSO in `arkcase-portal-server.yaml`
- Set `oidc` and `logingov` fields to true if we have Portal SSO Configuration

Example of the config for Portal SSO:
```
global:
  foia:
    sso:
      enabled: true
      protocol: "oidc"
      oidc: 
        portal:
          clientId: 
          clientSecret: 
          authorizationUri: 
          tokenUri: 
          userInfoUri: 
          jwkSetUri: 
          redirectUri: 
          logOutRedirectUri:
          scope: 
          clientAuthentication: 
          grantType: 
          responseType: 
          privateKeyFilePath:
          clientAssertionType: 
```