### PR TITLE
Remove quotes from `redirectUrl` for portal SSO

### DIFF
--- a/src/app/Chart.yaml
+++ b/src/app/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: app
-version: 0.8.0-83
+version: 0.8.0-84
 appVersion: "24.09.02"
 description: ArkCase Application Chart
 type: application

--- a/src/app/charts/core/Chart.yaml
+++ b/src/app/charts/core/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: core
-version: 0.8.0-53
+version: 0.8.0-54
 appVersion: "3.0.0"
 description: A Helm chart for core ArkCase and ConfigServer
 type: application

--- a/src/app/charts/core/templates/_helpers-sso.tpl
+++ b/src/app/charts/core/templates/_helpers-sso.tpl
@@ -145,7 +145,7 @@ idp.xml
 
         {{- /* Set the redirectUri to the specified value */ -}}
         {{- $portal := (include "arkcase.portal" $.ctx | fromYaml) -}}
-        {{- $baseUrlPortal := (printf "%s://%s/%s/portal/login" $.baseUrl.scheme $.baseUrl.hostname $portal.context | quote ) -}}
+        {{- $baseUrlPortal := (printf "%s://%s/%s/portal/login" $.baseUrl.scheme $.baseUrl.hostname $portal.context) -}}
         {{- $client = set $client "redirectUri" $baseUrlPortal -}}
 
         {{- if hasKey $client "clientAuthentication" -}}


### PR DESCRIPTION
Remove quotes from `redirectUrl` for portal SSO